### PR TITLE
docs: update readme to current travis ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.com/AlbertUlysses/Kanye_the_Wrapper.svg?branch=master)](https://travis-ci.com/AlbertUlysses/Kanye_the_Wrapper)
+[![Build Status](https://travis-ci.com/AlbertUlysses/kanyethewrapper.svg?branch=master)](https://travis-ci.com/AlbertUlysses/kanyethewrapper)
 # Kanye the Python Wrapper
 This is a wrapper for kanye.rest - a Free REST API for random Kanye West quotes by Andrew Jazbec.
 Thank You [Andrew!](https://github.com/ajzbc)


### PR DESCRIPTION
during renaming the readme was not updated to use the new Travis CI markdown path. Updated to show the right path